### PR TITLE
fix(package.json): update packageManager and add sharp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   "keywords": [],
   "author": "",
   "license": "LGPL-3.0-or-later",
-  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
+  "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",
   "engines": {
     "node": "22"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
+      "sharp",
       "svelte-preprocess"
     ]
   }


### PR DESCRIPTION
Downgraded pnpm version in packageManager to 10.9.0 for compatibility. Added 'sharp' to onlyBuiltDependencies to ensure proper handling of build requirements.